### PR TITLE
This hides some autogenerated files from the diff

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.map -diff
+classdocs.js -diff

--- a/docs/.gitattributes
+++ b/docs/.gitattributes
@@ -1,0 +1,2 @@
+categories.json -diff
+guides.json -diff

--- a/docs/api/.gitattributes
+++ b/docs/api/.gitattributes
@@ -1,0 +1,2 @@
+*.html -diff
+*.js -diff


### PR DESCRIPTION
To hide an autogenerated file make a `.gitattributes` file in the highest (furthest from root) directory that will encompass all the files you want to hide (so that as few files are affected as possible for wildcards), and add a lines like this:

```
filename.ext -diff
*.pattern -diff
```

The `-diff` tells git that this file shouldn't generate diff output.
