### PR TITLE
Fix attribute order firing

### DIFF
--- a/classes/slider.dre
+++ b/classes/slider.dre
@@ -68,11 +68,17 @@ SOFTWARE. -->
       <attribute name="value" type="number" value="0"></attribute>
       <handler event="onvalue" method="visualize"></handler>
       <setter name="value" args="v">
-          return Math.min(@maxvalue, Math.max(v, @minvalue))
+          if @inited
+            return Math.min(@maxvalue, Math.max(v, @minvalue))
+          else
+            return v
       </setter>
 
 
-      <handler event="oninit" method="visualize"></handler>
+      <handler event="oninit">
+        @setAttribute('value', @value)
+        @visualize()
+      </handler>
       <handler event="onwidth" method="visualize"></handler>
       <handler event="onheight" method="visualize"></handler>
 

--- a/core/dist/dreem.js
+++ b/core/dist/dreem.js
@@ -100,7 +100,7 @@
 ;
 
   window.dr = (function() {
-    var ArtSprite, AutoPropertyLayout, BitmapSprite, COMMENT_NODE, Class, Eventable, Events, Idle, InputTextSprite, Keyboard, Layout, Module, Mouse, Node, Path, Sprite, StartEventable, State, TextSprite, View, Window, _initConstraints, _processAttrs, callOnIdle, capabilities, clone, closeTo, compiler, constraintScopes, debug, dom, eventq, exports, handlerq, idle, ignoredAttributes, instantiating, matchEvent, matchPercent, mixOf, mouseEvents, noop, querystring, showWarnings, specialtags, starttime, tagPackageSeparator, test, warnings;
+    var ArtSprite, AutoPropertyLayout, BitmapSprite, COMMENT_NODE, Class, Eventable, Events, Idle, InputTextSprite, Keyboard, Layout, Module, Mouse, Node, Path, Sprite, StartEventable, State, TextSprite, View, Window, _initConstraints, _processAttrs, callOnIdle, capabilities, clone, closeTo, compiler, constraintScopes, debug, dom, eventq, exports, handlerq, idle, ignoredAttributes, instantiating, matchEvent, matchPercent, mixOf, mouseEvents, noop, querystring, reverseSort, showWarnings, specialtags, starttime, tagPackageSeparator, test, warnings;
     COMMENT_NODE = window.Node.COMMENT_NODE;
     noop = function() {};
     closeTo = function(a, b, epsilon) {
@@ -129,6 +129,15 @@
         }
       }
       return Mixed;
+    };
+    reverseSort = function(a, b) {
+      if (a < b) {
+        return 1;
+      }
+      if (b < a) {
+        return -1;
+      }
+      return 0;
     };
     matchPercent = /%$/;
     Events = 
@@ -1159,7 +1168,7 @@
         name = ref2[k];
         this.setAttribute(name, attributes[name]);
       }
-      ref3 = (function() {
+      ref3 = ((function() {
         var results;
         results = [];
         for (name in attributes) {
@@ -1168,7 +1177,7 @@
           }
         }
         return results;
-      })();
+      })()).sort(reverseSort);
       for (l = 0, len2 = ref3.length; l < len2; l++) {
         name = ref3[l];
         this.bindAttribute(name, attributes[name], tagname);

--- a/core/dreem.coffee
+++ b/core/dreem.coffee
@@ -72,6 +72,11 @@ window.dr = do ->
         Mixed::[name] = method
     Mixed
 
+  reverseSort = (a, b) ->
+    return 1 if (a < b)
+    return -1 if (b < a)
+    return 0
+
   matchPercent = /%$/
 
   Events = `~["include","fragments/Events.coffee"]~`

--- a/core/fragments/Node.coffee
+++ b/core/fragments/Node.coffee
@@ -181,7 +181,7 @@ class Node extends Eventable
       @setAttribute(name, attributes[name])
 
     # Bind to event expressions and set attributes
-    for name in (name for name of attributes when not (name in lateattributes or name in earlyattributes))
+    for name in (name for name of attributes when not (name in lateattributes or name in earlyattributes)).sort(reverseSort)
       @bindAttribute(name, attributes[name], tagname)
 
     # Need to fire subnode added events after attributes have been set since


### PR DESCRIPTION
[Delivers #89722672] by forcing attributes to be set in alphabetical
order. See /smoke/view.html which now passes across Firefox, Chrome and
Safari.