### PR TITLE
Replace postskinhack with document.fonts.ready

### DIFF
--- a/classes/buttonbase.dre
+++ b/classes/buttonbase.dre
@@ -140,20 +140,4 @@ SOFTWARE. -->
     if !@_fixedheight? then @_fixedheight = @innerheight > 0
   </method>
 
-  <method type="javascript" name="postSkinHack" args="v">
-    // This is a terrible solution, but currently I cannot track down what is causing the actual problem (it possibly may be a bug in chrome?)
-    // It seems as though the getBoundingClientRect() call (from Sprite.getBounds()) does not always
-    // update itself immediately when the font size/family/weight changes until a short, random time after
-    // the page has been loaded, which means the original sizeToDom() call has sized the component incorrectly and
-    // the handleResize has already happened.
-    // This hack forces the vulnerable components (i.e. those that auto-size) to resize themselves, but should
-    // be removed and replaced with a better solution as soon as there is one available.
-
-    var self = this;
-    setTimeout(function() {
-      self.label.sizeToDom();
-      self.handleResize();
-    }, 15);
-  </method>
-
 </class>

--- a/classes/sizetodom.dre
+++ b/classes/sizetodom.dre
@@ -140,7 +140,7 @@ SOFTWARE. -->
     */-->
   <method name="sizeToDom">
     bounds = @sprite.getBounds()
-    
+
     @__internalUpdate = true
     unless @__hasSetWidth then @set_width(bounds.width, true)
     unless @__hasSetHeight then @set_height(bounds.height, true)

--- a/classes/skin.dre
+++ b/classes/skin.dre
@@ -104,21 +104,20 @@
             @applyTo(subview)
 
         view.$appliedskin = @name
-        view.postSkinHack() if view.postSkinHack
 
     </method>
 </class>
 
 <skin name="default">
-  <text fontweight="200" clip="true" color="white" fontsize="20" fontfamily="'mission-gothic', 'Helvetica Neue', Helvetica, Arial, sans-serif"></text>
+  <text fontweight="200" clip="true" color="white" fontsize="20" fontfamily="'mission-gothic'"></text>
 
-  <inputtext bgcolor="rgb(63,63,63)" color="white" height="32" fontweight="300" fontsize="20" leftpadding="12" leftborder="2" bottomborder="2" bordercolor="white" fontfamily="'mission-gothic', 'Helvetica Neue', Helvetica, Arial, sans-serif">
+  <inputtext bgcolor="rgb(63,63,63)" color="white" height="32" fontweight="300" fontsize="20" leftpadding="12" leftborder="2" bottomborder="2" bordercolor="white" fontfamily="'mission-gothic'">
     <art name="indicator" fill="white" x="-9" visible="true"></art>
   </inputtext>
 
   <labelbutton border="2" padding="3" textcolor="rgb(207,207,207)" defaultcolor="rgb(63,63,63)">
     <art visible="true" name="indicator" fill="white"></art>
-    <text color="rgb(207,207,207)" name="label" fontweight="200" texttransform="uppercase" fontsize="20" fontfamily="'mission-gothic', 'Helvetica Neue', Helvetica, Arial, sans-serif"></text>
+    <text color="rgb(207,207,207)" name="label" texttransform="uppercase" fontweight="200" fontsize="20" fontfamily="'mission-gothic'"></text>
   </labelbutton>
 
   <rangeslider bottomborder="2" bordercolor="white" lowselectcolor="#a0a0a0" highselectcolor="#a0a0a0">
@@ -133,11 +132,11 @@
   </slider>
 
   <checkbutton border="2" padding="3" textcolor="rgb(140,140,140)" innerspacing="3">
-    <text color="rgb(140,140,140)" name="label" texttransform="uppercase" fontweight="200" fontsize="20" fontfamily="'mission-gothic', 'Helvetica Neue', Helvetica, Arial, sans-serif"></text>
+    <text color="rgb(140,140,140)" name="label" texttransform="uppercase" fontweight="200" fontsize="20" fontfamily="'mission-gothic'"></text>
   </checkbutton>
 
   <labeltoggle border="2" padding="3" textcolor="rgb(207,207,207)" defaultcolor="rgb(63,63,63)">
     <art visible="true" name="indicator" fill="white"></art>
-    <text color="rgb(207,207,207)" name="label" texttransform="uppercase" fontweight="200" fontsize="20" fontfamily="'mission-gothic', 'Helvetica Neue', Helvetica, Arial, sans-serif"></text>
+    <text color="rgb(207,207,207)" name="label" texttransform="uppercase" fontweight="200" fontsize="20" fontfamily="'mission-gothic'"></text>
   </labeltoggle>
 </skin>

--- a/classes/text.dre
+++ b/classes/text.dre
@@ -110,7 +110,7 @@ SOFTWARE. -->
     return dr._noop
   </setter>
 
-  <attribute name="fontweight" type="number" value=""></attribute>
+  <attribute name="fontweight" type="string" value=""></attribute>
   <setter name="fontweight" args="v">
     if @fontweight isnt v
       @sprite.setAttribute('fontweight', v)
@@ -173,13 +173,14 @@ SOFTWARE. -->
         */-->
   <attribute name="underline" type="boolean" value="false"></attribute>
   <setter name="underline" args="underline">
-    @setAndFire('underline', underline)
-    if underline
-      if @strike then @setAttribute('strike', false)
-      @sprite.setAttribute('text-decoration', 'underline')
-    else if not @strike
-      @sprite.setAttribute('text-decoration', 'none')
-    if @inited then @sizeToDom()
+    if @underline isnt underline
+      @setAndFire('underline', underline)
+      if underline
+        if @strike then @setAttribute('strike', false)
+        @sprite.setAttribute('text-decoration', 'underline')
+      else if not @strike
+        @sprite.setAttribute('text-decoration', 'none')
+      if @inited then @sizeToDom()
     return dr._noop
   </setter>
 
@@ -189,13 +190,14 @@ SOFTWARE. -->
         */-->
   <attribute name="strike" type="boolean" value="false"></attribute>
   <setter name="strike" args="strike">
-    @setAndFire('strike', strike)
-    if strike
-      if @underline then @setAttribute('underline', false)
-      @sprite.setAttribute('text-decoration', 'line-through')
-    else if not @underline
-      @sprite.setAttribute('text-decoration', 'none')
-    if @inited then @sizeToDom()
+    if @strike isnt strike
+      @setAndFire('strike', strike)
+      if strike
+        if @underline then @setAttribute('underline', false)
+        @sprite.setAttribute('text-decoration', 'line-through')
+      else if not @underline
+        @sprite.setAttribute('text-decoration', 'none')
+      if @inited then @sizeToDom()
     return dr._noop
   </setter>
 
@@ -265,8 +267,8 @@ SOFTWARE. -->
 
   <method name="construct" args="el, attributes">
     # setup default to reduce events during initialization.
-    @fontsize = @fontfamily = ''
-    @bold = @italic = @smallcaps = @multiline = @ellipsis = false
+    @text = @fontsize = @fontfamily = @texttransform = @fontweight = ''
+    @strike = @underline = @bold = @italic = @smallcaps = @multiline = @ellipsis = false
 
     @super()
   </method>
@@ -279,6 +281,16 @@ SOFTWARE. -->
   <method name="_preventBadWhitespace">
     if @multiline then @sprite.setAttribute('whitespace', if @__hasSetWidth then 'pre-wrap' else 'pre')
   </method>
+
+  <handler event="oninit">
+    #on chrome the text objects need to be informed when the fonts on the page have finally finished loading so they can recalculate their proper size
+    if document.fonts && document.fonts.ready && document.fonts.ready.constructor == Promise
+      slf = @
+      document.fonts.ready.then () ->
+        slf.sizeToDom()
+
+  </handler>
+
 
   <!--/**
         * @method format


### PR DESCRIPTION
Fixes issues on chrome where calculations are taking place before fonts are loaded.

*Note: Safari doesn't implement fonts loading properly yet, so this is still a bug on Safari.*