### PR TITLE
On instantiation, add dom objects directly instead of via innerHTML

### DIFF
--- a/classes/inputtext.dre
+++ b/classes/inputtext.dre
@@ -125,13 +125,13 @@ SOFTWARE. -->
     @replicator.updateData(newdata)
   </handler>
 
-  <!--<art name="indicator" y="${this.parent.height - this.height - 5}" height="10" width="10" z="1" inline="true" visible="false" clickable="false">-->
-      <!--&lt;!&ndash;-->
-      <!--<svg name="triangle" height="100" width="100">-->
-          <!--<polygon name="polygon" points="0,100 0,0 100,100"/>-->
-      <!--</svg>-->
-      <!--&ndash;&gt;-->
-  <!--</art>-->
+  <art name="indicator" y="${this.parent.height - this.height - 5}" height="10" width="10" z="1" inline="true" visible="false" clickable="false">
+      <!--
+      <svg name="triangle" height="100" width="100">
+          <polygon name="polygon" points="0,100 0,0 100,100"/>
+      </svg>
+      -->
+  </art>
 
   <handler event="oninit">
     @text ?= @sprite.getText()

--- a/core/dist/dreem.js
+++ b/core/dist/dreem.js
@@ -4896,7 +4896,7 @@
         console.warn('overwriting class', name);
       }
       dr[name] = klass = function(instanceel, instanceattributes, internal, skipchildren) {
-        var attributes, children, div, element, elements, k, l, len3, len4, len5, m, parent, ref1, sendInit, viewel;
+        var attributes, children, div, e, element, elements, k, l, len3, len4, len5, m, parent, ref1, sendInit, viewel;
         attributes = clone(classattributes);
         _processAttrs(instanceattributes, attributes);
         if (attributes.$instanceattributes == null) {
@@ -4922,7 +4922,16 @@
           if (instancebody) {
             div = document.createElement('div');
             div.innerHTML = instancebody;
-            elements = div.childNodes;
+            elements = ((function() {
+              var k, len3, ref2, results;
+              ref2 = div.childNodes;
+              results = [];
+              for (k = 0, len3 = ref2.length; k < len3; k++) {
+                e = ref2[k];
+                results.push(e);
+              }
+              return results;
+            })()).reverse();
             if (viewel.firstChild) {
               for (k = 0, len3 = elements.length; k < len3; k++) {
                 element = elements[k];

--- a/core/dist/dreem.js
+++ b/core/dist/dreem.js
@@ -4193,7 +4193,7 @@
               url: window.location.pathname
             },
             success: function(data) {
-              if (data.length) {
+              if (data.length && data[0].length) {
                 showWarnings(data);
               }
               return setTimeout(filereloader, 1000);
@@ -4896,7 +4896,7 @@
         console.warn('overwriting class', name);
       }
       dr[name] = klass = function(instanceel, instanceattributes, internal, skipchildren) {
-        var attributes, children, k, len3, parent, ref1, sendInit, viewel, viewhtml;
+        var attributes, children, div, element, elements, k, l, len3, len4, len5, m, parent, ref1, sendInit, viewel;
         attributes = clone(classattributes);
         _processAttrs(instanceattributes, attributes);
         if (attributes.$instanceattributes == null) {
@@ -4920,20 +4920,32 @@
         }
         if (viewel) {
           if (instancebody) {
-            viewhtml = viewel.innerHTML.trim();
-            if (viewhtml) {
-              viewel.innerHTML = instancebody + viewhtml;
+            div = document.createElement('div');
+            div.innerHTML = instancebody;
+            elements = div.childNodes;
+            if (viewel.firstChild) {
+              for (k = 0, len3 = elements.length; k < len3; k++) {
+                element = elements[k];
+                if (element) {
+                  viewel.insertBefore(element, viewel.firstChild);
+                }
+              }
             } else {
-              viewel.innerHTML = instancebody;
+              for (l = 0, len4 = elements.length; l < len4; l++) {
+                element = elements[l];
+                if (element) {
+                  viewel.appendChild(element);
+                }
+              }
             }
           }
           if (!skipchildren) {
             children = (function() {
-              var k, len3, ref2, ref3, results;
+              var len5, m, ref2, ref3, results;
               ref2 = dom.getChildElements(viewel);
               results = [];
-              for (k = 0, len3 = ref2.length; k < len3; k++) {
-                child = ref2[k];
+              for (m = 0, len5 = ref2.length; m < len5; m++) {
+                child = ref2[m];
                 if (ref3 = child.localName, indexOf.call(specialtags, ref3) < 0) {
                   results.push(child);
                 }
@@ -4941,8 +4953,8 @@
               return results;
             })();
             if (!skipinitchildren) {
-              for (k = 0, len3 = children.length; k < len3; k++) {
-                child = children[k];
+              for (m = 0, len5 = children.length; m < len5; m++) {
+                child = children[m];
                 dom.initElement(child, parent);
               }
             }

--- a/core/fragments/Class.coffee
+++ b/core/fragments/Class.coffee
@@ -134,14 +134,15 @@ class Class
       # unpack instance children
       if viewel
         if instancebody
-          viewhtml = viewel.innerHTML.trim()
-          if viewhtml
-            # Append class children on instances instead of replacing them
-            viewel.innerHTML = instancebody + viewhtml
-            # console.log 'instancebody', instancebody, viewel.innerHTML, viewel
+          div = document.createElement('div');
+          div.innerHTML = instancebody;
+          elements = div.childNodes;
+          if viewel.firstChild
+            for element in elements
+              viewel.insertBefore(element, viewel.firstChild) if element
           else
-            # console.log 'normal'
-            viewel.innerHTML = instancebody
+            for element in elements
+              viewel.appendChild(element) if element
 
         unless skipchildren
           children = (child for child in dom.getChildElements(viewel) when child.localName not in specialtags)

--- a/core/fragments/Class.coffee
+++ b/core/fragments/Class.coffee
@@ -136,7 +136,7 @@ class Class
         if instancebody
           div = document.createElement('div');
           div.innerHTML = instancebody;
-          elements = div.childNodes;
+          elements = (e for e in div.childNodes).reverse()
           if viewel.firstChild
             for element in elements
               viewel.insertBefore(element, viewel.firstChild) if element

--- a/smoke/button.html
+++ b/smoke/button.html
@@ -27,11 +27,11 @@
       assert.testCaseLabel = 'labelbutton tests';
       
       assert.equal(@text, 'Text');
-      @testsize(0,0,55,24,10,0);
+      @testsize(0,0,40,24,0,0);
 
       @setAttribute('text', 'NewText');
       assert.equal(@text, 'NewText');
-      @testsize(0,0,100,24,10,0);
+      @testsize(0,0,75,24,0,0);
     </handler>
   </labelbuttontest>
 
@@ -66,11 +66,11 @@
       assert.testCaseLabel = 'labelbutton tests, fixed height';
 
       assert.equal(@text, 'Text');
-      @testsize(0,0,55,100,11,38);
+      @testsize(0,0,40,100,0,38);
 
       @setAttribute('text', 'NewText');
       assert.equal(@text, 'NewText');
-      @testsize(0,0,100,100,11,38);
+      @testsize(0,0,75,100,0,38);
     </handler>
   </labelbuttontest>
 
@@ -94,11 +94,11 @@
       assert.testCaseLabel = 'labeltoggle tests';
 
       assert.equal(@text, 'Text');
-      @testsize(0,0,55,24,10,0);
+      @testsize(0,0,40,24,0,0);
 
       @setAttribute('text', 'NewText');
       assert.equal(@text, 'NewText');
-      @testsize(0,0,100,24,10,0);
+      @testsize(0,0,75,24,0,0);
     </handler>
   </labeltoggletest>
 
@@ -129,11 +129,11 @@
       assert.testCaseLabel = 'labeltoggle tests, fixed height';
 
       assert.equal(@text, 'Text');
-      @testsize(0,0,55,100,11,38);
+      @testsize(0,0,40,100,0,38);
 
       @setAttribute('text', 'NewText');
       assert.equal(@text, 'NewText');
-      @testsize(0,0,100,100,11,38);
+      @testsize(0,0,75,100,0,38);
     </handler>
   </labeltoggletest>
 


### PR DESCRIPTION
In Class.coffee during ininitliazation, the previous approach used innerHTML to set the instance's views, but this was clobbering/overwriting any children that the view's constructor or sprite may have set up.  This was breaking the textinput (and any of the other input-type classes).