### PR TITLE
Tests now work with all PhantomJS versions

### DIFF
--- a/bin/phantomrunner.js
+++ b/bin/phantomrunner.js
@@ -25,7 +25,9 @@ for(var i = 0; i < list.length; i++){
 }
 
 var runTest = function (file, callback) {
-  var out = []
+  var out = [];
+  var errors = [];
+
   var tId;
   var processOutput = function() {
     var expectedarry = page.evaluateJavaScript(function () {
@@ -42,12 +44,18 @@ var runTest = function (file, callback) {
     var gotoutput = out.join("\n")
     var expectedoutput = expectedarry.join("\n")
     if (gotoutput !== expectedoutput) {
-      console.log('ERROR: unexpected output expected::::');
+      console.log('ERROR: unexpected output:');
+      console.log('+++expected++++++++++++++++++++++++++++++++');
       console.log(expectedoutput)
-      console.log('but got::::::::::::::::::::::::::::::');
+      console.log('---actual----------------------------------');
       console.log(gotoutput)
+      console.log('===========================================');
       console.log("\n")
     }
+    if (errors.length > 0 && (gotoutput !== expectedoutput || expectedarry.length == 0)) {
+      console.error(errors.join("\n"))
+    }
+
     page.close();
     callback();
   }
@@ -70,7 +78,8 @@ var runTest = function (file, callback) {
         msgStack.push(' -> ' + (t.file || t.sourceURL) + ': ' + t.line + (t.function ? ' (in function ' + t.function +')' : ''));
       });
     }
-    console.error(msgStack.join('\n'));
+    out.push(msg)
+    errors.push(msgStack.join('\n'))
     updateTimer(0);
     exitCode = 1;
   };

--- a/bin/phantomrunner.js
+++ b/bin/phantomrunner.js
@@ -30,16 +30,32 @@ var runTest = function (file, callback) {
 
   var tId;
   var processOutput = function() {
-    var expectedarry = page.evaluateJavaScript(function () {
-      var retarry = [];
-      $('expectedoutput').contents().filter(function(){
-        return this.nodeType == 8;
-      }).each(function(i, e){
-          retarry.push($.trim(e.nodeValue))
-        });
 
-      return retarry;
-    });
+    // Below shouldn't have to duplicate this code, but can't find a way to use or pass phantom.version.major
+    // in/into the 'evaluateJavaScript' without it blowing up (even building a string beforehand), but it works fine like this.
+    // This maybe a bug in phantomjs, or maybe I'm dumb, but either way, if this can be cleaned up in the future, pls do.
+    var jsfunction;
+    if (phantom.version.major == 1) {
+      jsfunction = function () {
+        var retarry = [];
+        $('expectedoutput[excludever!="1"]').contents().filter(function(){
+          return this.nodeType == 8;
+        }).each(function(i, e) { retarry.push($.trim(e.nodeValue)) });
+        return retarry;
+      };
+    } else {
+      jsfunction = function () {
+        var retarry = [];
+        $('expectedoutput[excludever!="2"]').contents().filter(function(){
+          return this.nodeType == 8;
+        }).each(function(i, e) { retarry.push($.trim(e.nodeValue)) });
+        return retarry;
+      };
+    }
+    // (once we move completely to phantomjs2.0, the above can be removed and replaced with a single function
+    // checking expectedoutput without the excludever clause)
+
+    var expectedarry = page.evaluateJavaScript(jsfunction);
 
     var gotoutput = out.join("\n")
     var expectedoutput = expectedarry.join("\n")

--- a/smoke/misc.html
+++ b/smoke/misc.html
@@ -1,7 +1,12 @@
 <html>
-<expectedoutput>
+<expectedoutput excludever="1">
   <!--
   Invalid tag undefined [object HTMLUnknownElement]
+  -->
+</expectedoutput>
+<expectedoutput excludever="2">
+  <!--
+  Invalid tag undefined [object HTMLElement]
   -->
 </expectedoutput>
 <head>
@@ -29,7 +34,7 @@
   <view>
     <labeltoggle></labeltoggle>
   </view>
-  
+
   <!-- embedded <'s in the code -->
   <view>
     <handler event="oninit">

--- a/smoke/misc.html
+++ b/smoke/misc.html
@@ -1,7 +1,7 @@
 <html>
 <expectedoutput>
   <!--
-  Invalid tag undefined [object HTMLElement]
+  Invalid tag undefined [object HTMLUnknownElement]
   -->
 </expectedoutput>
 <head>

--- a/smoke/replication.html
+++ b/smoke/replication.html
@@ -152,23 +152,23 @@
     <dataset name="tempdata3" url="/examples/data/weather.json"></dataset>
 
     <spacedlayout axis="y" spacing="15"></spacedlayout>
-    <replicator datapath="$tempdata3" classname="weather"></replicator>
+    <replicator name="a" datapath="$tempdata3" classname="weather"></replicator>
 
     <replicator name="repl" datapath="$tempdata3" classname="weather2"></replicator>
 
-    <replicator datapath="$tempdata3/main/temp" classname="text"></replicator>
+    <replicator name="b" datapath="$tempdata3/main/temp" classname="text"></replicator>
 
     <handler event="ondata" reference="this.tempdata3">
       var _this = this;
-      dr.idle.callOnIdle(function() {
-        assert.equal(_this.subviews.length, 3)
+      setTimeout(function() {
+        assert.equal(_this.subviews.length, 3, "in idle")
         assert.equal(_this.subnodes.length, 10)
         assert.equal(_this.subviews[_this.subviews.length - 1].text, '63.88');
 
         dr.idle.callOnIdle(function() {
           assert.equal(_this.subviews[_this.subviews.length - 1].width, 45);
         })
-      })
+      }, 500)
     </handler>
   </view>
 


### PR DESCRIPTION
If the two versions have different output for the same error, you can now use `excludever="#"` to deselect output for comparison, such as in `misc.html`.